### PR TITLE
feat: use ClientWithMiddleware instead of Client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ itertools = "0.12.1"
 bisection = "0.1.0"
 memmap2 = "0.9.0"
 reqwest = { version = "0.11.22", default-features = false, features = ["stream"] }
+reqwest-middleware = "0.2.4"
 tokio = { version = "1.33.0", default-features = false }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tokio-util = "0.7.9"
@@ -29,21 +30,3 @@ async_zip = { version = "0.0.15", default-features = false, features = ["tokio"]
 assert_matches = "1.5.0"
 rstest = { version = "0.18.2" }
 url = { version = "2.4.1" }
-
-# The profile that 'cargo dist' will build with
-[profile.dist]
-inherits = "release"
-lto = "thin"
-
-# Config for 'cargo dist'
-[workspace.metadata.dist]
-# The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.3.1"
-# CI backends to support
-ci = ["github"]
-# The installers to generate for each app
-installers = []
-# Target platforms to build apps for (Rust target-triple syntax)
-targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-pc-windows-msvc"]
-# Publish jobs to run in CI
-pr-run-mode = "plan"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,25 +1,33 @@
 use std::sync::Arc;
 
+/// Error type used for [`crate::AsyncHttpRangeReader`]
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum AsyncHttpRangeReaderError {
+    /// The server does not support range requests
     #[error("range requests are not supported")]
     HttpRangeRequestUnsupported,
 
+    /// Other HTTP error
     #[error(transparent)]
-    HttpError(#[from] Arc<reqwest::Error>),
+    HttpError(#[from] Arc<reqwest_middleware::Error>),
 
+    /// An error occurred during transport
     #[error("an error occurred during transport: {0}")]
-    TransportError(#[source] Arc<reqwest::Error>),
+    TransportError(#[source] Arc<reqwest_middleware::Error>),
 
+    /// An IO error occurred
     #[error("io error occurred: {0}")]
     IoError(#[source] Arc<std::io::Error>),
 
+    /// Content-Range header is missing from response
     #[error("content-range header is missing from response")]
     ContentRangeMissing,
 
+    /// Content-Length header is missing from response
     #[error("content-length header is missing from response")]
     ContentLengthMissing,
 
+    /// Memory mapping the file failed
     #[error("memory mapping the file failed")]
     MemoryMapError(#[source] Arc<std::io::Error>),
 }
@@ -30,8 +38,14 @@ impl From<std::io::Error> for AsyncHttpRangeReaderError {
     }
 }
 
+impl From<reqwest_middleware::Error> for AsyncHttpRangeReaderError {
+    fn from(err: reqwest_middleware::Error) -> Self {
+        AsyncHttpRangeReaderError::TransportError(Arc::new(err))
+    }
+}
+
 impl From<reqwest::Error> for AsyncHttpRangeReaderError {
     fn from(err: reqwest::Error) -> Self {
-        AsyncHttpRangeReaderError::TransportError(Arc::new(err))
+        AsyncHttpRangeReaderError::TransportError(Arc::new(err.into()))
     }
 }

--- a/src/sparse_range.rs
+++ b/src/sparse_range.rs
@@ -65,8 +65,7 @@ impl SparseRange {
         // Compute the bounds of covered range taking into account existing covered ranges.
         let start = left_slice
             .first()
-            .map(|&left_bound| left_bound.min(range_start))
-            .unwrap_or(range_start);
+            .map_or(range_start, |&left_bound| left_bound.min(range_start));
 
         // Get the ranges that are missing
         let mut bound = start;
@@ -79,8 +78,7 @@ impl SparseRange {
 
         let end = right_slice
             .last()
-            .map(|&right_bound| right_bound.max(range_end))
-            .unwrap_or(range_end);
+            .map_or(range_end, |&right_bound| right_bound.max(range_end));
 
         bound > end
     }
@@ -93,7 +91,7 @@ impl SparseRange {
     }
 
     /// Find the ranges that are uncovered for the specified range together with what the
-    /// SparseRange would look like if we covered that range.
+    /// [`SparseRange`] would look like if we covered that range.
     pub fn cover(&self, range: Range<u64>) -> Option<(SparseRange, Vec<RangeInclusive<u64>>)> {
         let range_start = range.start;
         let range_end = range.end - 1;
@@ -109,12 +107,10 @@ impl SparseRange {
         // Compute the bounds of covered range taking into account existing covered ranges.
         let start = left_slice
             .first()
-            .map(|&left_bound| left_bound.min(range_start))
-            .unwrap_or(range_start);
+            .map_or(range_start, |&left_bound| left_bound.min(range_start));
         let end = right_slice
             .last()
-            .map(|&right_bound| right_bound.max(range_end))
-            .unwrap_or(range_end);
+            .map_or(range_end, |&right_bound| right_bound.max(range_end));
 
         // Get the ranges that are missing
         let mut ranges = Vec::new();
@@ -126,10 +122,12 @@ impl SparseRange {
             bound = right_bound + 1;
         }
         if bound <= end {
-            ranges.push(bound..=end)
+            ranges.push(bound..=end);
         }
 
-        if !ranges.is_empty() {
+        if ranges.is_empty() {
+            None
+        } else {
             let mut new_left = self.left.clone();
             new_left.splice(left_index..right_index, [start]);
             let mut new_right = self.right.clone();
@@ -141,8 +139,6 @@ impl SparseRange {
                 },
                 ranges,
             ))
-        } else {
-            None
         }
     }
 }


### PR DESCRIPTION
Replaces `Client` with `ClientWithMiddleware` to additional control over authentication.

Most of this work was done in https://github.com/mamba-org/rattler/pull/488 by @vlad-ivanov-name .

I've moved this work back into this repository because I feel its very separate from rattler. Initially, the idea was that this crate would use types from the rattler repository but since that didn't happen there is no reason to keep it there I think.