### PR TITLE
Add a Builder struct and use it in from_[head|tail]_response

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -49,3 +49,19 @@ impl From<reqwest::Error> for AsyncHttpRangeReaderError {
         AsyncHttpRangeReaderError::TransportError(Arc::new(err.into()))
     }
 }
+
+/// Error type used for [`crate::AsyncHttpRangeReaderBuilder`]
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum AsyncHttpRangeReaderBuilderError {
+    /// Required field 'client' is missing
+    #[error("required field 'client' is missing")]
+    MissingClient,
+
+    /// Required field 'url' is missing
+    #[error("required field 'url' is missing")]
+    MissingUrl,
+
+    /// Memory mapping the file failed
+    #[error("memory mapping the file failed")]
+    MemoryMapError(#[source] Arc<std::io::Error>),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,10 @@ pub enum AsyncHttpRangeReaderError {
     /// Memory mapping the file failed
     #[error("memory mapping the file failed")]
     MemoryMapError(#[source] Arc<std::io::Error>),
+
+    /// Error building the reader
+    #[error("error building the reader: {0}")]
+    BuilderError(#[source] Arc<AsyncHttpRangeReaderBuilderError>),
 }
 
 impl From<std::io::Error> for AsyncHttpRangeReaderError {
@@ -47,6 +51,12 @@ impl From<reqwest_middleware::Error> for AsyncHttpRangeReaderError {
 impl From<reqwest::Error> for AsyncHttpRangeReaderError {
     fn from(err: reqwest::Error) -> Self {
         AsyncHttpRangeReaderError::TransportError(Arc::new(err.into()))
+    }
+}
+
+impl From<AsyncHttpRangeReaderBuilderError> for AsyncHttpRangeReaderError {
+    fn from(err: AsyncHttpRangeReaderBuilderError) -> Self {
+        AsyncHttpRangeReaderError::BuilderError(Arc::new(err))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub use error::AsyncHttpRangeReaderError;
 ///     if response.status() == reqwest::StatusCode::NOT_MODIFIED {
 ///         Ok(None)
 ///     } else {
-///         let reader = AsyncHttpRangeReader::from_head_response(client, response, HeaderMap::default()).await?;
+///         let reader = AsyncHttpRangeReader::from_head_response(client, response, HeaderMap::default())?;
 ///         Ok(Some(reader))
 ///     }
 /// }
@@ -156,7 +156,7 @@ impl AsyncHttpRangeReader {
                 )
                 .await?;
                 let response_headers = response.headers().clone();
-                let self_ = Self::from_tail_response(client, response, extra_headers).await?;
+                let self_ = Self::from_tail_response(client, response, extra_headers)?;
                 Ok((self_, response_headers))
             }
             CheckSupportMethod::Head => {
@@ -164,7 +164,7 @@ impl AsyncHttpRangeReader {
                     Self::initial_head_request(client.clone(), url.clone(), HeaderMap::default())
                         .await?;
                 let response_headers = response.headers().clone();
-                let self_ = Self::from_head_response(client, response, extra_headers).await?;
+                let self_ = Self::from_head_response(client, response, extra_headers)?;
                 Ok((self_, response_headers))
             }
         }
@@ -197,7 +197,7 @@ impl AsyncHttpRangeReader {
 
     /// Initialize the reader from [`AsyncHttpRangeReader::initial_tail_request`] (or a user
     /// provided response that also has a range of bytes from the end as body)
-    pub async fn from_tail_response(
+    pub fn from_tail_response(
         client: impl Into<reqwest_middleware::ClientWithMiddleware>,
         tail_request_response: Response,
         extra_headers: HeaderMap,
@@ -297,7 +297,7 @@ impl AsyncHttpRangeReader {
 
     /// Initialize the reader from [`AsyncHttpRangeReader::initial_head_request`] (or a user
     /// provided response the)
-    pub async fn from_head_response(
+    pub fn from_head_response(
         client: impl Into<reqwest_middleware::ClientWithMiddleware>,
         head_response: Response,
         extra_headers: HeaderMap,


### PR DESCRIPTION
Hello there 👋🏻 I was intrigued by the discussion in #11, and so I've made this PR to allow for a more Builder-like pattern of creating a reader instance. Part of my reason for the PR is just to get a bit of Rust practice. If this code is far away from what you would want in this repo, then I will not be offended 😄