### PR TITLE
chore: Update reqwest-middleware from 0.3.0 to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
+checksum = "d1ccd3b55e711f91a9885a2fa6fbbb2e39db1776420b062efc058c6410f7e5e3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ itertools = "0.13.0"
 bisection = "0.1.0"
 memmap2 = "0.9.0"
 reqwest = { version = "0.12.3", default-features = false, features = ["stream"] }
-reqwest-middleware = "0.3.0"
+reqwest-middleware = "0.4.0"
 tokio = { version = "1.33.0", default-features = false }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tokio-util = "0.7.9"


### PR DESCRIPTION
Update reqwest-middleware to its latest version.

## reqwest-middleware 0.4.0

### Breaking Changes

- `request_middleware::Error` is now a transparent error enum and doesn't add its own context anymore.